### PR TITLE
Standings endpoints

### DIFF
--- a/NHL.NET.Test/StandingsTests.cs
+++ b/NHL.NET.Test/StandingsTests.cs
@@ -1,0 +1,152 @@
+﻿using NHL.NET.Constants;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NHL.NET.Test
+{
+    public class StandingsTests
+    {
+        private const string Season = "20132014";
+        private readonly NHLClient _nhlClient = new();
+
+        [Fact]
+        public async Task Test_GetCurrentAsync_ByRegularSeason_ReturnsRegularSeasonStandings()
+        {
+            var response = await _nhlClient.Standings.GetCurrentAsync();
+
+            Assert.NotNull(response);
+            // Should be 4 divisions
+            Assert.True(response.Records.Count == 4);
+            Assert.True(response.Records.All(x => x.StandingsType == StandingsTypes.RegularSeason));
+        }
+
+        [Fact]
+        public async Task Test_GetCurrentAsync_ByDivision_ReturnsDivisionStandings()
+        {
+            var response = await _nhlClient.Standings.GetCurrentAsync(StandingsTypes.ByDivision);
+
+            Assert.NotNull(response);
+            // Should be 4 divisions
+            Assert.True(response.Records.Count == 4);
+            Assert.True(response.Records.All(x => x.StandingsType == StandingsTypes.ByDivision));
+        }
+
+        [Fact]
+        public async Task Test_GetCurrentAsync_ByConference_ReturnsConferenceStandings()
+        {
+            var response = await _nhlClient.Standings.GetCurrentAsync(StandingsTypes.ByConference);
+
+            Assert.NotNull(response);
+            // Should be 2 conferences.
+            Assert.True(response.Records.Count == 2);
+            Assert.True(response.Records.All(x => x.StandingsType == StandingsTypes.ByConference));
+        }
+
+        [Fact]
+        public async Task Test_GetBySeasonAsync_ReturnsRegularSeasonStandings()
+        {
+            var response = await _nhlClient.Standings.GetBySeasonAsync(Season);
+
+            Assert.NotNull(response);
+            Assert.True(response.Records.All(x => x.Season == Season));
+            Assert.True(response.Records.All(x => x.StandingsType == StandingsTypes.RegularSeason));
+        }
+
+        [Fact]
+        public async Task Test_GetBySeasonAsync_ByConference_ReturnsConferenceStandings()
+        {
+            var response = await _nhlClient.Standings.GetBySeasonAsync(Season, StandingsTypes.ByConference);
+
+            Assert.NotNull(response);
+            Assert.True(response.Records.All(x => x.Season == Season));
+            Assert.True(response.Records.All(x => x.StandingsType == StandingsTypes.ByConference));
+            // 2 Conferences
+            Assert.True(response.Records.Count == 2);
+        }
+
+        [Fact]
+        public async Task Test_GetBySeasonAsync_EmptyString_ReturnsNull()
+        {
+            var response = await _nhlClient.Standings.GetBySeasonAsync("");
+            Assert.Null(response);
+        }
+
+        [Fact]
+        public async Task Test_GetBySeasonAsync_InvalidSeason_ReturnsEmptyRecords()
+        {
+            var response = await _nhlClient.Standings.GetBySeasonAsync("89756702");
+            Assert.True(response.Records.Count == 0);
+        }
+
+        [Fact]
+        public void Test_GetCurrent_ByRegularSeason_ReturnsRegularSeasonStandings()
+        {
+            var response = _nhlClient.Standings.GetCurrent();
+
+            Assert.NotNull(response);
+            Assert.True(response.Records.Count == 4);
+            Assert.True(response.Records.All(x => x.StandingsType == StandingsTypes.RegularSeason));
+        }
+    
+        [Fact]
+        public void Test_GetCurrent_ByDivision_ReturnsDivisionStandings()
+        {
+            var response = _nhlClient.Standings.GetCurrent(StandingsTypes.ByDivision);
+
+            Assert.NotNull(response);
+            // Should be 4 divisions
+            Assert.True(response.Records.Count == 4);
+            Assert.True(response.Records.All(x => x.StandingsType == StandingsTypes.ByDivision));
+        }
+   
+        [Fact]
+        public void Test_GetCurrent_ByConference_ReturnsConferenceStandings()
+        {
+            var response = _nhlClient.Standings.GetCurrent(StandingsTypes.ByConference);
+
+            Assert.NotNull(response);
+            // Should be 2 conferences.
+            Assert.True(response.Records.Count == 2);
+            Assert.True(response.Records.All(x => x.StandingsType == StandingsTypes.ByConference));
+        }
+    
+        [Fact]
+        public void Test_GetBySeason_ReturnsRegularSeasonStandings()
+        {
+            var response = _nhlClient.Standings.GetBySeason(Season);
+
+            Assert.NotNull(response);
+            Assert.True(response.Records.All(x => x.Season == Season));
+            Assert.True(response.Records.All(x => x.StandingsType == StandingsTypes.RegularSeason));
+        }
+
+        [Fact]
+        public void Test_GetBySeason_ByConference_ReturnsConferenceStandings()
+        {
+            var response = _nhlClient.Standings.GetBySeason(Season, StandingsTypes.ByConference);
+
+            Assert.NotNull(response);
+            Assert.True(response.Records.All(x => x.Season == Season));
+            Assert.True(response.Records.All(x => x.StandingsType == StandingsTypes.ByConference));
+        }
+
+        [Fact]
+        public void Test_GetBySeason_EmptyString_ReturnsNull()
+        {
+            var response = _nhlClient.Standings.GetBySeason("");
+
+            Assert.Null(response);
+        }
+    
+        [Fact]
+        public void Test_GetBySeason_InvalidSeason_ReturnsEmptyRecords()
+        {
+            var response = _nhlClient.Standings.GetBySeason("89756702");
+            Assert.True(response.Records.Count == 0);
+        }
+    }
+}

--- a/NHL.NET/Constants/StandingsTypes.cs
+++ b/NHL.NET/Constants/StandingsTypes.cs
@@ -1,0 +1,23 @@
+﻿namespace NHL.NET.Constants
+{
+    public static class StandingsTypes
+    {
+        public const string RegularSeason = "regularSeason";
+
+        public const string DivisionLeaders = "divisionLeaders";
+
+        public const string Wildcard = "wildCard";
+
+        public const string WildcardwithLeaders = "wildCardWithLeaders";
+
+        public const string Preseason = "preseason";
+ 
+        public const string Postseason = "postseason";
+
+        public const string ByDivision = "byDivision";
+
+        public const string ByConference = "byConference";
+
+        public const string ByLeague = "byLeague";
+    }
+}

--- a/NHL.NET/Constants/Urls.cs
+++ b/NHL.NET/Constants/Urls.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace NHL.NET.Constants
+﻿namespace NHL.NET.Constants
 {
     public static class Urls
     {
@@ -13,5 +9,7 @@ namespace NHL.NET.Constants
         public static readonly string TeamUrl = $"{StatsApiUrl}teams";
 
         public static readonly string DivisionUrl = $"{StatsApiUrl}divisions";
+
+        public static readonly string StandingsUrl = $"{StatsApiUrl}standings";
     }
 }

--- a/NHL.NET/Endpoints/Standings/IStandingsEndpoints.cs
+++ b/NHL.NET/Endpoints/Standings/IStandingsEndpoints.cs
@@ -1,0 +1,17 @@
+﻿using NHL.NET.Constants;
+using NHL.NET.Models.Standings;
+using System.Threading.Tasks;
+
+namespace NHL.NET.Endpoints.Standings
+{
+    public interface IStandingsEndpoints
+    {
+        Task<NHLStandings> GetCurrentAsync(string standingsType = StandingsTypes.RegularSeason);
+
+        Task<NHLStandings> GetBySeasonAsync(string season, string standingsType = StandingsTypes.RegularSeason);
+
+        NHLStandings GetBySeason(string season, string standingsType = StandingsTypes.RegularSeason);
+
+        NHLStandings GetCurrent(string standingsType = StandingsTypes.RegularSeason);
+    }
+}

--- a/NHL.NET/Endpoints/Standings/StandingsEndpoints.cs
+++ b/NHL.NET/Endpoints/Standings/StandingsEndpoints.cs
@@ -1,0 +1,60 @@
+﻿using NHL.NET.Constants;
+using NHL.NET.Http.Interfaces;
+using NHL.NET.Models.Standings;
+using System.Threading.Tasks;
+
+namespace NHL.NET.Endpoints.Standings
+{
+    public class StandingsEndpoints : IStandingsEndpoints
+    {
+        private readonly IRequester _requester;
+        public StandingsEndpoints(IRequester requester)
+        {
+            _requester = requester;
+        }
+
+        #region Async
+
+        public async Task<NHLStandings> GetCurrentAsync(string standingsType = StandingsTypes.RegularSeason)
+        {
+            var response = await _requester.GetRequestAsync<NHLStandings>($"{Urls.StandingsUrl}?standingsType={standingsType}");
+            return response;
+        }
+
+        public async Task<NHLStandings> GetBySeasonAsync(string season, string standingsType = StandingsTypes.RegularSeason)
+        {
+            if (string.IsNullOrEmpty(season))
+            {
+                return null;
+            }
+
+            var response = await _requester.GetRequestAsync<NHLStandings>($"{Urls.StandingsUrl}?season={season}&standingsType={standingsType}");
+            return response;
+        }
+
+        #endregion
+
+        #region Sync
+
+        public NHLStandings GetCurrent(string standingsType = StandingsTypes.RegularSeason)
+        {
+            var response = _requester.GetRequest<NHLStandings>($"{Urls.StandingsUrl}?standingsType={standingsType}");
+            return response;
+        }
+
+        public NHLStandings GetBySeason(string season, string standingsType = StandingsTypes.RegularSeason)
+        {
+            if (string.IsNullOrEmpty(season))
+            {
+                return null;
+            }
+
+            var response = _requester.GetRequest<NHLStandings>($"{Urls.StandingsUrl}?season={season}&standingsType={standingsType}");
+            return response;
+        }
+
+        #endregion
+
+
+    }
+}

--- a/NHL.NET/Models/League/SimpleLeague.cs
+++ b/NHL.NET/Models/League/SimpleLeague.cs
@@ -1,0 +1,9 @@
+﻿namespace NHL.NET.Models.League
+{
+    public class SimpleLeague
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/NHL.NET/Models/Record/LeagueRecord.cs
+++ b/NHL.NET/Models/Record/LeagueRecord.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace NHL.NET.Models.Record
+{
+    public class LeagueRecord
+    {
+        public int Wins { get; set; }
+
+        public int Losses { get; set; }
+
+        [JsonProperty(PropertyName = "ot")]
+        public int OvertimeLosses { get; set; }
+
+        public string Type { get; set; }
+    }
+}

--- a/NHL.NET/Models/Record/TeamRecord.cs
+++ b/NHL.NET/Models/Record/TeamRecord.cs
@@ -1,0 +1,70 @@
+﻿using Newtonsoft.Json;
+using NHL.NET.Models.Streak;
+using NHL.NET.Models.Team;
+using System;
+
+namespace NHL.NET.Models.Record
+{
+    public class TeamRecord
+    {
+        public NHLSimpleTeam Team { get; set; }
+
+        public LeagueRecord LeagueRecord { get; set; }
+
+        public int RegulationWins { get; set; }
+
+        public int GoalsAgainst { get; set; }
+
+        public int GoalsScored { get; set; }
+
+        public int Points { get; set; }
+
+        public int DivisionRank { get; set; }
+
+        [JsonProperty(PropertyName = "divisionL10Rank")]
+        public int DivisionLastTenRank { get; set; }
+
+        public int DivisionRoadRank { get; set; }
+
+        public int DivisionHomeRank { get; set; }
+
+        public int ConferenceRank { get; set; }
+
+        [JsonProperty(PropertyName = "conferenceL10Rank")]
+        public int ConferenceLastTenRank { get; set; }
+
+        public int ConferenceRoadRank { get; set; }
+
+        public int ConferenceHomeRank { get; set; }
+
+        public int LeagueRank { get; set; }
+
+        [JsonProperty(PropertyName = "leagueL10Rank")]
+        public int LeagueLastTenRank { get; set; }
+
+        public int LeagueRoadRank { get; set; }
+
+        public int LeagueHomeRank { get; set; }
+
+        public int WildCardRank { get; set; }
+
+        public int Row { get; set; }
+
+        public int GamePlayed { get; set; }
+
+        public SimpleStreak Streak { get; set; }
+
+        public float PointsPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "ppDivisionRank")]
+        public int PowerplayDivisionRank { get; set; }
+
+        [JsonProperty(PropertyName = "ppConferenceRank")]
+        public int PowerplayConferenceRank { get; set; }
+
+        [JsonProperty(PropertyName = "ppLeagueRank")]
+        public int PowerplayLeagueRank { get; set; }
+
+        public DateTime LastUpdated { get; set; }
+    }
+}

--- a/NHL.NET/Models/Standings/NHLStandings.cs
+++ b/NHL.NET/Models/Standings/NHLStandings.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace NHL.NET.Models.Standings
+{
+    public class NHLStandings
+    {
+        public List<NHLStandingsRecord> Records { get; set; }
+    }
+}

--- a/NHL.NET/Models/Standings/NHLStandingsRecord.cs
+++ b/NHL.NET/Models/Standings/NHLStandingsRecord.cs
@@ -1,0 +1,21 @@
+﻿using NHL.NET.Models.League;
+using NHL.NET.Models.Record;
+using System.Collections.Generic;
+
+namespace NHL.NET.Models.Standings
+{
+    public class NHLStandingsRecord
+    {
+        public string StandingsType { get; set; }
+
+        public string Season { get; set; }
+
+        public SimpleLeague League { get; set; }
+
+        public NHLSimpleDivision Division { get; set; }
+
+        public NHLSimpleConference Conference { get; set; }
+
+        public List<TeamRecord> TeamRecords { get; set; }
+    }
+}

--- a/NHL.NET/Models/Streak/SimpleStreak.cs
+++ b/NHL.NET/Models/Streak/SimpleStreak.cs
@@ -1,0 +1,21 @@
+﻿namespace NHL.NET.Models.Streak
+{
+    public class SimpleStreak
+    {
+        /// <summary>
+        /// Wins/Losses
+        /// </summary>
+        public string StreakType { get; set; }
+
+        /// <summary>
+        /// Length of the streak
+        /// </summary>
+        public int StreakNumber { get; set; }
+
+        /// <summary>
+        /// Type and number formed into a code.
+        /// Ex. Type = Wins, number = 8. Code = W8.
+        /// </summary>
+        public string StreakCode { get; set; }
+    }
+}

--- a/NHL.NET/Models/Team/NHLSimpleTeam.cs
+++ b/NHL.NET/Models/Team/NHLSimpleTeam.cs
@@ -1,0 +1,9 @@
+﻿namespace NHL.NET.Models.Team
+{
+    public class NHLSimpleTeam
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/NHL.NET/NHLClient.cs
+++ b/NHL.NET/NHLClient.cs
@@ -1,5 +1,6 @@
 ﻿using NHL.NET.Endpoints.Division;
 using NHL.NET.Endpoints.Franchise;
+using NHL.NET.Endpoints.Standings;
 using NHL.NET.Endpoints.Team;
 using NHL.NET.Http;
 
@@ -10,6 +11,7 @@ namespace NHL.NET
         public ITeamEndpoint Team { get; }
         public IFranchiseEndpoint Franchise { get; }
         public IDivisionEndpoint Division { get; }
+        public IStandingsEndpoints Standings { get; set; }
 
         public NHLClient()
         {
@@ -18,6 +20,7 @@ namespace NHL.NET
             Franchise = new FranchiseEndpoint(requester);
             Team = new TeamEndpoint(requester);
             Division = new DivisionEndpoint(requester);
+            Standings = new StandingsEndpoints(requester);
         }
     }
 }


### PR DESCRIPTION
Added standings endpoints and associated tests:

- GetCurrentAsync / GetCurrent
- GetBySeasonAsync / GetBySeason

Can now retrieve standings for the current season or a specific season (ex. 20132014). The standings can be sorted or modified by passing a StandingsTypes (ex. StandingsTypes.ByConference) and is set to StandingsTypes.RegularSeason by default.