### PR TITLE
Made the clients properties plural

### DIFF
--- a/NHL.NET.Test/DivisionTests.cs
+++ b/NHL.NET.Test/DivisionTests.cs
@@ -11,7 +11,7 @@ namespace NHL.NET.Test
         [Fact]
         public async Task Test_GetAllAsync_ReturnsAllDivisions()
         {
-            var response = await _nhlClient.Division.GetAllAsync();
+            var response = await _nhlClient.Divisions.GetAllAsync();
 
             Assert.NotNull(response);
             Assert.NotNull(response.Divisions);
@@ -21,7 +21,7 @@ namespace NHL.NET.Test
         [Fact]
         public async Task Test_GetByIdAsync_ReturnsDivision()
         {
-            var response = await _nhlClient.Division.GetByIdAsync(2);
+            var response = await _nhlClient.Divisions.GetByIdAsync(2);
 
             Assert.NotNull(response);
             Assert.NotNull(response.Conference);
@@ -33,7 +33,7 @@ namespace NHL.NET.Test
         [Fact]
         public async Task Test_GetMultipleAsync_ReturnsDivisions()
         {
-            var response = await _nhlClient.Division.GetMultipleAsync(new List<int> { 1, 2, 3 });
+            var response = await _nhlClient.Divisions.GetMultipleAsync(new List<int> { 1, 2, 3 });
 
             Assert.NotNull(response);
             Assert.True(response.Divisions.Count == 3);
@@ -43,7 +43,7 @@ namespace NHL.NET.Test
         [Fact]
         public void Test_GetAll_ReturnsAllDivisions()
         {
-            var response = _nhlClient.Division.GetAll();
+            var response = _nhlClient.Divisions.GetAll();
 
             Assert.NotNull(response);
             Assert.NotNull(response.Divisions);
@@ -53,7 +53,7 @@ namespace NHL.NET.Test
         [Fact]
         public void Test_GetById_ReturnsDivision()
         {
-            var response = _nhlClient.Division.GetById(2);
+            var response = _nhlClient.Divisions.GetById(2);
 
             Assert.NotNull(response);
             Assert.NotNull(response.Conference);
@@ -65,7 +65,7 @@ namespace NHL.NET.Test
         [Fact]
         public void Test_GetMultiple_ReturnsDivisions()
         {
-            var response = _nhlClient.Division.GetMultiple(new List<int> { 1, 2, 3 });
+            var response = _nhlClient.Divisions.GetMultiple(new List<int> { 1, 2, 3 });
 
             Assert.NotNull(response);
             Assert.True(response.Divisions.Count == 3);

--- a/NHL.NET.Test/FranchiseTests.cs
+++ b/NHL.NET.Test/FranchiseTests.cs
@@ -11,7 +11,7 @@ namespace NHL.NET.Test
         [Fact]
         public async Task Test_GetAllAsync_ReturnsAllFranchises()
         {
-            var response = await _nhlClient.Franchise.GetAllAsync();
+            var response = await _nhlClient.Franchises.GetAllAsync();
 
             Assert.NotNull(response);
             Assert.NotNull(response.Franchises);
@@ -21,7 +21,7 @@ namespace NHL.NET.Test
         [Fact]
         public void Test_GetAll_ReturnsAllFranchises()
         {
-            var response = _nhlClient.Franchise.GetAll();
+            var response = _nhlClient.Franchises.GetAll();
 
             Assert.NotNull(response);
             Assert.NotNull(response.Franchises);
@@ -31,7 +31,7 @@ namespace NHL.NET.Test
         [Fact]
         public async Task Test_GetByIdAsync_ReturnsFranchise()
         {
-            var response = await _nhlClient.Franchise.GetByIdAsync(5);
+            var response = await _nhlClient.Franchises.GetByIdAsync(5);
 
             Assert.NotNull(response);
             Assert.Equal("Maple Leafs", response.TeamName);
@@ -41,7 +41,7 @@ namespace NHL.NET.Test
         [Fact]
         public void Test_GetById_ReturnsFranchise()
         {
-            var response = _nhlClient.Franchise.GetById(5);
+            var response = _nhlClient.Franchises.GetById(5);
 
             Assert.NotNull(response);
             Assert.Equal("Maple Leafs", response.TeamName);
@@ -51,7 +51,7 @@ namespace NHL.NET.Test
         [Fact]
         public async Task Test_GetMultipleAsync_ReturnsFranchises()
         {
-            var response = await _nhlClient.Franchise.GetMultipleByIdAsync(new List<int> { 1, 2, 3 });
+            var response = await _nhlClient.Franchises.GetMultipleByIdAsync(new List<int> { 1, 2, 3 });
 
             Assert.NotNull(response);
             Assert.NotNull(response.Franchises);
@@ -61,7 +61,7 @@ namespace NHL.NET.Test
         [Fact]
         public void Test_GetMultiple_ReturnsFranchises()
         {
-            var response = _nhlClient.Franchise.GetMultipleById(new List<int> { 1, 2, 3 });
+            var response = _nhlClient.Franchises.GetMultipleById(new List<int> { 1, 2, 3 });
 
             Assert.NotNull(response);
             Assert.NotNull(response.Franchises);

--- a/NHL.NET.Test/TeamTests.cs
+++ b/NHL.NET.Test/TeamTests.cs
@@ -11,7 +11,7 @@ namespace NHL.NET.Test
         [Fact]
         public async Task Test_GetAllAsync_ReturnsAllTeams()
         {
-            var response = await _nhlClient.Team.GetAllAsync();
+            var response = await _nhlClient.Teams.GetAllAsync();
 
             Assert.NotNull(response);
             Assert.NotNull(response.Teams);
@@ -21,7 +21,7 @@ namespace NHL.NET.Test
         [Fact]
         public async Task Test_GetByIdAsync_ReturnsTeam()
         {
-            var response = await _nhlClient.Team.GetByIdAsync(6);
+            var response = await _nhlClient.Teams.GetByIdAsync(6);
 
             Assert.NotNull(response);
             Assert.Equal("Boston", response.LocationName);
@@ -31,7 +31,7 @@ namespace NHL.NET.Test
         [Fact]
         public async Task Test_GetMultipleAsync_ReturnsTeamList()
         {
-            var response = await _nhlClient.Team.GetMultipleAsync(new List<int> { 1, 2, 3 });
+            var response = await _nhlClient.Teams.GetMultipleAsync(new List<int> { 1, 2, 3 });
 
             Assert.NotNull(response);
             Assert.True(response.Teams.Count == 3);
@@ -40,7 +40,7 @@ namespace NHL.NET.Test
         [Fact]
         public void Test_GetAll_ReturnsAllTeams()
         {
-            var response = _nhlClient.Team.GetAll();
+            var response = _nhlClient.Teams.GetAll();
 
             Assert.NotNull(response);
             Assert.NotNull(response.Teams);
@@ -50,7 +50,7 @@ namespace NHL.NET.Test
         [Fact]
         public void Test_GetById_ReturnsTeam()
         {
-            var response = _nhlClient.Team.GetById(6);
+            var response = _nhlClient.Teams.GetById(6);
 
             Assert.NotNull(response);
             Assert.Equal("Boston", response.LocationName);
@@ -60,7 +60,7 @@ namespace NHL.NET.Test
         [Fact]
         public void Test_GetMultiple_ReturnsTeamList()
         {
-            var response = _nhlClient.Team.GetMultiple(new List<int> { 1, 2, 3 });
+            var response = _nhlClient.Teams.GetMultiple(new List<int> { 1, 2, 3 });
 
             Assert.NotNull(response);
             Assert.True(response.Teams.Count == 3);

--- a/NHL.NET/NHLClient.cs
+++ b/NHL.NET/NHLClient.cs
@@ -9,9 +9,9 @@ namespace NHL.NET
 {
     public class NHLClient
     {
-        public ITeamEndpoint Team { get; }
-        public IFranchiseEndpoint Franchise { get; }
-        public IDivisionEndpoint Division { get; }
+        public ITeamEndpoint Teams { get; }
+        public IFranchiseEndpoint Franchises { get; }
+        public IDivisionEndpoint Divisions { get; }
         public IStandingsEndpoints Standings { get; set; }
         public IConferenceEndpoints Conferences { get; set; }
 
@@ -19,9 +19,9 @@ namespace NHL.NET
         {
             var requester = new Requester();
 
-            Franchise = new FranchiseEndpoint(requester);
-            Team = new TeamEndpoint(requester);
-            Division = new DivisionEndpoint(requester);
+            Franchises = new FranchiseEndpoint(requester);
+            Teams = new TeamEndpoint(requester);
+            Divisions = new DivisionEndpoint(requester);
             Standings = new StandingsEndpoints(requester);
             Conferences = new ConferenceEndpoints(requester);
         }


### PR DESCRIPTION
Made the NHLClient's properties plural (teams, franchises, conferences, divisions, etc.). It just makes more sense and feels better when consuming.