### PR TITLE
Team stats

### DIFF
--- a/NHL.NET.Test/TeamTests.cs
+++ b/NHL.NET.Test/TeamTests.cs
@@ -29,6 +29,14 @@ namespace NHL.NET.Test
         }
 
         [Fact]
+        public async Task Test_GetTeamStatsAsync_ReturnsTeamStats()
+        {
+            var response = await _nhlClient.Teams.GetTeamStatsAsync(5);
+
+            Assert.NotNull(response);
+        }
+
+        [Fact]
         public async Task Test_GetMultipleAsync_ReturnsTeamList()
         {
             var response = await _nhlClient.Teams.GetMultipleAsync(new List<int> { 1, 2, 3 });
@@ -64,6 +72,14 @@ namespace NHL.NET.Test
 
             Assert.NotNull(response);
             Assert.True(response.Teams.Count == 3);
+        }
+
+        [Fact]
+        public void Test_GetTeamStats_ReturnsTeamStats()
+        {
+            var response = _nhlClient.Teams.GetTeamStats(5);
+
+            Assert.NotNull(response);
         }
     }
 }

--- a/NHL.NET.Test/TeamTests.cs
+++ b/NHL.NET.Test/TeamTests.cs
@@ -51,6 +51,14 @@ namespace NHL.NET.Test
         }
 
         [Fact]
+        public async Task Test_GetTeamStatsAsync_EmptySeason_ReturnsTeamStats()
+        {
+            var response = await _nhlClient.Teams.GetTeamStatsAsync(5, "");
+
+            Assert.NotNull(response);
+        }
+
+        [Fact]
         public async Task Test_GetMultipleAsync_ReturnsTeamList()
         {
             var response = await _nhlClient.Teams.GetMultipleAsync(new List<int> { 1, 2, 3 });
@@ -108,6 +116,14 @@ namespace NHL.NET.Test
 
             Assert.NotEqual(firstSeason.Wins, secondSeason.Wins);
             Assert.NotEqual(firstSeason.GoalsPerGame, secondSeason.GoalsPerGame);
+        }
+
+        [Fact]
+        public void Test_GetTeamStats_EmptySeason_ReturnsTeamStats()
+        {
+            var response = _nhlClient.Teams.GetTeamStats(5, "");
+
+            Assert.NotNull(response);
         }
     }
 }

--- a/NHL.NET.Test/TeamTests.cs
+++ b/NHL.NET.Test/TeamTests.cs
@@ -37,6 +37,20 @@ namespace NHL.NET.Test
         }
 
         [Fact]
+        public async Task Test_GetTeamStatsAsync_SpecificSeason_ReturnsTeamStats()
+        {
+            // Compare 2 different seasons to verify different stats were returned.
+            var firstSeason = await _nhlClient.Teams.GetTeamStatsAsync(5, "20102011");
+            var secondSeason = await _nhlClient.Teams.GetTeamStatsAsync(5, "20092010");
+
+            Assert.NotNull(firstSeason);
+            Assert.NotNull(secondSeason);
+
+            Assert.NotEqual(firstSeason.Wins, secondSeason.Wins);
+            Assert.NotEqual(firstSeason.GoalsPerGame, secondSeason.GoalsPerGame);
+        }
+
+        [Fact]
         public async Task Test_GetMultipleAsync_ReturnsTeamList()
         {
             var response = await _nhlClient.Teams.GetMultipleAsync(new List<int> { 1, 2, 3 });
@@ -80,6 +94,20 @@ namespace NHL.NET.Test
             var response = _nhlClient.Teams.GetTeamStats(5);
 
             Assert.NotNull(response);
+        }
+
+        [Fact]
+        public void Test_GetTeamStats_SpecificSeason_ReturnsTeamStats()
+        {
+            // Compare 2 different seasons to verify different stats were returned.
+            var firstSeason = _nhlClient.Teams.GetTeamStats(5, "20102011");
+            var secondSeason = _nhlClient.Teams.GetTeamStats(5, "20092010");
+
+            Assert.NotNull(firstSeason);
+            Assert.NotNull(secondSeason);
+
+            Assert.NotEqual(firstSeason.Wins, secondSeason.Wins);
+            Assert.NotEqual(firstSeason.GoalsPerGame, secondSeason.GoalsPerGame);
         }
     }
 }

--- a/NHL.NET/Endpoints/Team/ITeamEndpoint.cs
+++ b/NHL.NET/Endpoints/Team/ITeamEndpoint.cs
@@ -6,11 +6,11 @@ namespace NHL.NET.Endpoints.Team
 {
     public interface ITeamEndpoint
     {
-        Task<NHLTeamStats> GetTeamStatsAsync(int teamId);
+        Task<NHLTeamStats> GetTeamStatsAsync(int teamId, string season = "");
         Task<NHLTeamList> GetAllAsync();
         Task<NHLTeam> GetByIdAsync(int teamId);
         Task<NHLTeamList> GetMultipleAsync(List<int> teamIds);
-        NHLTeamStats GetTeamStats(int teamId);
+        NHLTeamStats GetTeamStats(int teamId, string season = "");
         NHLTeamList GetAll();
         NHLTeam GetById(int teamId);
         NHLTeamList GetMultiple(List<int> teamIds);

--- a/NHL.NET/Endpoints/Team/ITeamEndpoint.cs
+++ b/NHL.NET/Endpoints/Team/ITeamEndpoint.cs
@@ -6,9 +6,11 @@ namespace NHL.NET.Endpoints.Team
 {
     public interface ITeamEndpoint
     {
+        Task<NHLTeamStats> GetTeamStatsAsync(int teamId);
         Task<NHLTeamList> GetAllAsync();
         Task<NHLTeam> GetByIdAsync(int teamId);
         Task<NHLTeamList> GetMultipleAsync(List<int> teamIds);
+        NHLTeamStats GetTeamStats(int teamId);
         NHLTeamList GetAll();
         NHLTeam GetById(int teamId);
         NHLTeamList GetMultiple(List<int> teamIds);

--- a/NHL.NET/Endpoints/Team/TeamEndpoint.cs
+++ b/NHL.NET/Endpoints/Team/TeamEndpoint.cs
@@ -43,9 +43,16 @@ namespace NHL.NET.Endpoints.Team
             return teamList;
         }
 
-        public async Task<NHLTeamStats> GetTeamStatsAsync(int teamId)
+        public async Task<NHLTeamStats> GetTeamStatsAsync(int teamId, string season = "")
         {
-            var jsonString = await _requester.GetRequestAsync($"{Urls.TeamUrl}/{teamId}/stats");
+            var queryString = "";
+            if (!string.IsNullOrEmpty(season))
+            {
+                // Only add query string if a season was given.
+                queryString = $"?season={season}";
+            }
+
+            var jsonString = await _requester.GetRequestAsync($"{Urls.TeamUrl}/{teamId}/stats{queryString}");
             if (string.IsNullOrEmpty(jsonString))
             {
                 return null;
@@ -86,9 +93,16 @@ namespace NHL.NET.Endpoints.Team
             return teamList;
         }
 
-        public NHLTeamStats GetTeamStats(int teamId)
+        public NHLTeamStats GetTeamStats(int teamId, string season = "")
         {
-            var jsonString = _requester.GetRequest($"{Urls.TeamUrl}/{teamId}/stats");
+            var queryString = "";
+            if (!string.IsNullOrEmpty(season))
+            {
+                // Only add query string if a season was given.
+                queryString = $"?season={season}";
+            }
+
+            var jsonString = _requester.GetRequest($"{Urls.TeamUrl}/{teamId}/stats{queryString}");
             if (string.IsNullOrEmpty(jsonString))
             {
                 return null;

--- a/NHL.NET/Endpoints/Team/TeamEndpoint.cs
+++ b/NHL.NET/Endpoints/Team/TeamEndpoint.cs
@@ -1,5 +1,7 @@
-﻿using NHL.NET.Constants;
+﻿using Newtonsoft.Json.Linq;
+using NHL.NET.Constants;
 using NHL.NET.Http.Interfaces;
+using NHL.NET.Json;
 using NHL.NET.Models.Team;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -41,6 +43,20 @@ namespace NHL.NET.Endpoints.Team
             return teamList;
         }
 
+        public async Task<NHLTeamStats> GetTeamStatsAsync(int teamId)
+        {
+            var jsonString = await _requester.GetRequestAsync($"{Urls.TeamUrl}/{teamId}/stats");
+            if (string.IsNullOrEmpty(jsonString))
+            {
+                return null;
+            }
+
+            // The API response contains 2 different objects in a single array.
+            // This makes parsing more complicated than simply using JsonConvert.
+            var parsed = JObject.Parse(jsonString);
+            return parsed.ParseTeamStats();
+        }
+
         #endregion
 
         #region Sync
@@ -68,6 +84,20 @@ namespace NHL.NET.Endpoints.Team
             var teamList = _requester.GetRequest<NHLTeamList>($"{Urls.TeamUrl}?{queryString}");
 
             return teamList;
+        }
+
+        public NHLTeamStats GetTeamStats(int teamId)
+        {
+            var jsonString = _requester.GetRequest($"{Urls.TeamUrl}/{teamId}/stats");
+            if (string.IsNullOrEmpty(jsonString))
+            {
+                return null;
+            }
+
+            // The API response contains 2 different objects in a single array.
+            // This makes parsing more complicated than simply using JsonConvert.
+            var parsed = JObject.Parse(jsonString);
+            return parsed.ParseTeamStats();
         }
 
         #endregion

--- a/NHL.NET/Http/Interfaces/IRequester.cs
+++ b/NHL.NET/Http/Interfaces/IRequester.cs
@@ -1,13 +1,33 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace NHL.NET.Http.Interfaces
 {
     public interface IRequester
     {
+        /// <summary>
+        /// Asyncronously deserializes the response json to an object.
+        /// </summary>
+        /// <typeparam name="T">Object to deserialize to</typeparam>
+        /// <param name="uri">Uri to query</param>
         Task<T> GetRequestAsync<T>(string uri) where T : class;
+
+        /// <summary>
+        /// Asyncronously retrieves the response json as a string.
+        /// </summary>
+        /// <param name="uri">Uri to query</param>
+        Task<string> GetRequestAsync(string uri);
+
+        /// <summary>
+        /// Deserializes the response json to an object.
+        /// </summary>
+        /// <typeparam name="T">Object to deserialize to</typeparam>
+        /// <param name="uri">Uri to query</param>
         T GetRequest<T>(string uri) where T : class;
+
+        /// <summary>
+        /// Retrieves the response json as a string.
+        /// </summary>
+        /// <param name="uri">Uri to query</param>
+        string GetRequest(string uri);
     }
 }

--- a/NHL.NET/Http/Requester.cs
+++ b/NHL.NET/Http/Requester.cs
@@ -34,6 +34,21 @@ namespace NHL.NET.Http
             }
         }
 
+        public async Task<string> GetRequestAsync(string uri)
+        {
+            var req = new HttpRequestMessage(HttpMethod.Get, uri);
+            var response = await _client.SendAsync(req);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return await response.Content.ReadAsStringAsync();
+            }
+            else
+            {
+                return null;
+            }
+        }
+
         public T GetRequest<T>(string uri) where T : class
         {
             var req = new HttpRequestMessage(HttpMethod.Get, uri);
@@ -42,6 +57,21 @@ namespace NHL.NET.Http
             if (response.IsSuccessStatusCode)
             {
                 return JsonConvert.DeserializeObject<T>(response.Content.ReadAsStringAsync().Result);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public string GetRequest(string uri)
+        {
+            var req = new HttpRequestMessage(HttpMethod.Get, uri);
+            var response = _client.SendAsync(req).Result;
+
+            if (response.IsSuccessStatusCode)
+            {
+                return response.Content.ReadAsStringAsync().Result;
             }
             else
             {

--- a/NHL.NET/Json/TeamStatsReader.cs
+++ b/NHL.NET/Json/TeamStatsReader.cs
@@ -1,0 +1,126 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NHL.NET.Models.Team;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NHL.NET.Json
+{
+    internal static class TeamStatsReader
+    {
+        public static List<NHLTeamNumericStatSplit> GetTeamNumericStatSplits(this JObject jsonObject)
+        {
+            try
+            {
+                // The object we want from the array contains a statsType display name of statsSingleSeason.
+                var singleSeasonStatSplits = jsonObject["stats"].Where(x => x["type"].Value<string>("displayName") == "statsSingleSeason");
+                // The stats object is an array and we only care about the first object (Never seen more than one object in that array anyway).
+                var statArray = JArray.Parse(JsonConvert.SerializeObject(singleSeasonStatSplits))[0]["splits"];
+                return JsonConvert.DeserializeObject<List<NHLTeamNumericStatSplit>>(JsonConvert.SerializeObject(statArray));
+            }
+            catch (Exception ex)
+            {
+                // TODO: Some log output so the consumer understands why the result is null.
+                return null;
+            }
+        }
+
+        public static List<NHLTeamRankStatSplit> GetTeamStatRankSplits(this JObject jsonObject)
+        {
+            try
+            {
+                // The object we want from the array contains a statsType display name of regularSeasonStatRankings.
+                var statRankingSplits = jsonObject["stats"].Where(x => x["type"].Value<string>("displayName") == "regularSeasonStatRankings");
+                // The stats object is an array and we only care about the first object (Never seen more than one object in that array anyway).
+                var statArray = JArray.Parse(JsonConvert.SerializeObject(statRankingSplits))[0]["splits"];
+                return JsonConvert.DeserializeObject<List<NHLTeamRankStatSplit>>(JsonConvert.SerializeObject(statArray));
+            }
+            catch (Exception ex)
+            {
+                // TODO: Some log output so the consumer understands why the result is null.
+                return null;
+            }
+        }
+
+        public static NHLTeamStats ParseTeamStats(this JObject jsonObject)
+        {
+            // Get the numeric and rank stats objects from the single stats array.
+            var numeric = jsonObject.GetTeamNumericStatSplits().FirstOrDefault()?.Stat;
+            var rank = jsonObject.GetTeamStatRankSplits().FirstOrDefault()?.Stat;
+
+            if (numeric is null || rank is null)
+            {
+                return null;
+            }
+
+            // Flatten the array objects into a single object.
+            // This just ends up feeling much more logical to consumers.
+            return new NHLTeamStats()
+            {
+                GamesPlayed = numeric.GamesPlayed,
+                Wins = numeric.Wins,
+                WinsRank = rank.Wins,
+                Losses = numeric.Losses,
+                LossesRank = rank.Losses,
+                OvertimeLosses = numeric.OvertimeLosses,
+                OvertimeLossesRank = rank.OvertimeLosses,
+                Points = numeric.Points,
+                PointsRank = rank.Points,
+                PointsPercentage = numeric.PointsPercentage,
+                PointsPercentageRank = rank.PointsPercentage,
+
+                GoalsPerGame = numeric.GoalsPerGame,
+                GoalsPerGameRank = rank.GoalsPerGame,
+                GoalsAgainstPerGame = numeric.GoalsAgainstPerGame,
+                GoalsAgainstPerGameRank = rank.GoalsAgainstPerGame,
+
+                PowerPlayPercentage = numeric.PowerPlayPercentage,
+                PowerPlayRank = rank.PowerPlayPercentage,
+                PowerPlayGoals = numeric.PowerPlayGoals,
+                PowerPlayGoalsRank = rank.PowerPlayGoals,
+                PowerPlayGoalsAgainst = numeric.PowerPlayGoalsAgainst,
+                PowerPlayGoalsAgainstRank = rank.PowerPlayGoalsAgainst,
+                PowerPlayOpportunities = numeric.PowerPlayOpportunities,
+
+                PowerPlayOpportunitiesRank = rank.PowerPlayOpportunities,
+                PenaltyKillPercentage = numeric.PenaltyKillPercentage,
+                PenaltyKillRank = rank.PenaltyKillPercentage,
+
+                ShotsPerGame = numeric.ShotsPerGame,
+                ShotsPerGameRank = rank.ShotsPerGame,
+                ShotsAllowed = numeric.ShotsAllowed,
+                ShotsAllowedRank = rank.ShotsAllowed,
+
+                ScoreFirstWinPercentage = numeric.ScoreFirstWinPercentage,
+                ScoreFirstWinPercentageRank = rank.ScoreFirstWinPercentage,
+                OppScoreFirstWinPercentage = numeric.OppScoreFirstWinPercentage,
+                OppScoreFirstWinPercentageRank = rank.OppScoreFirstWinPercentage,
+
+                LeadAfterFirstWinPercentage = numeric.LeadAfterFirstWinPercentage,
+                LeadAfterFirstWinPercentageRank = rank.LeadAfterFirstWinPercentage,
+                LeadAfterSecondWinPercentage = numeric.LeadAfterSecondWinPercentage,
+                LeadAfterSecondWinPercentageRank = rank.LeadAfterSecondWinPercentage,
+
+                OutshootWinPercentage = numeric.OutshootWinPercentage,
+                OutshootWinPercentageRank = rank.OutshootWinPercentage,
+                OutshotWinPercentage = numeric.OutshotWinPercentage,
+                OutshotWinPercentageRank = rank.OutshotWinPercentage,
+
+                FaceoffsTaken = numeric.FaceoffsTaken,
+                FaceoffsTakenRank = rank.FaceoffsTaken,
+                FaceoffsWon = numeric.FaceoffsWon,
+                FaceoffsWonRank = rank.FaceoffsWon,
+                FaceoffsLost = numeric.FaceoffsLost,
+                FaceoffsLostRank = rank.FaceoffsLost,
+                FaceoffWinPercentage = numeric.FaceoffWinPercentage,
+                FaceoffWinPercentageRank = rank.FaceoffWinPercentage,
+
+                ShootingPercentage = numeric.ShootingPercentage,
+                ShootingPercentageRank = rank.ShootingPercentage,
+                SavePercentage = numeric.SavePercentage,
+                SavePercentageRank = rank.SavePercentage
+            };
+        }
+    }
+}

--- a/NHL.NET/Models/Stats/StatsGameType.cs
+++ b/NHL.NET/Models/Stats/StatsGameType.cs
@@ -1,0 +1,11 @@
+﻿namespace NHL.NET.Models.Stats
+{
+    public class StatsGameType
+    {
+        public string Id { get; set; }
+
+        public string Description { get; set; }
+
+        public bool Postseason { get; set; }
+    }
+}

--- a/NHL.NET/Models/Stats/StatsType.cs
+++ b/NHL.NET/Models/Stats/StatsType.cs
@@ -1,0 +1,9 @@
+﻿namespace NHL.NET.Models.Stats
+{
+    public class StatsType
+    {
+        public string DisplayName { get; set; }
+
+        public StatsGameType GameType { get; set; }
+    }
+}

--- a/NHL.NET/Models/Team/NHLTeamNumericStatSplit.cs
+++ b/NHL.NET/Models/Team/NHLTeamNumericStatSplit.cs
@@ -1,0 +1,139 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace NHL.NET.Models.Team
+{
+    internal class TeamNumericStat
+    {
+        public int GamesPlayed { get; set; }
+        public int Wins { get; set; }
+
+        public int Losses { get; set; }
+
+        [JsonProperty(PropertyName = "ot")]
+        public int OvertimeLosses { get; set; }
+
+        [JsonProperty(PropertyName = "pts")]
+        public int Points { get; set; }
+
+        [JsonProperty(PropertyName = "ptPctg")]
+        public float PointsPercentage { get; set; }
+
+        public float GoalsPerGame { get; set; }
+
+        public float GoalsAgainstPerGame { get; set; }
+
+        public float PowerPlayPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "powerPlayGoals")]
+        private float PowerPlayGoalsValue { get; set; }
+
+        [JsonIgnore]
+        public int PowerPlayGoals
+        {
+            get
+            {
+                return Convert.ToInt32(this.PowerPlayGoalsValue);
+            }
+        }
+
+        [JsonProperty(PropertyName = "powerPlayGoalsAgainst")]
+        private float PowerPlayGoalsAgainstValue { get; set; }
+
+        [JsonIgnore]
+        public int PowerPlayGoalsAgainst
+        {
+            get
+            {
+                return Convert.ToInt32(this.PowerPlayGoalsAgainstValue);
+            }
+        }
+
+
+        [JsonProperty(PropertyName = "powerPlayOpportunities")]
+        private float PowerPlayOpportunitiesValue { get; set; }
+
+
+        [JsonIgnore]
+        public int PowerPlayOpportunities
+        {
+            get
+            {
+                return Convert.ToInt32(this.PowerPlayOpportunitiesValue);
+            }
+        }
+
+        public float PenaltyKillPercentage { get; set; }
+
+        public float ShotsPerGame { get; set; }
+
+        public float ShotsAllowed { get; set; }
+
+        [JsonProperty(PropertyName = "winScoreFirst")]
+        public float ScoreFirstWinPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "winOppScoreFirst")]
+        public float OppScoreFirstWinPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "winLeadFirstPer")]
+        public float LeadAfterFirstWinPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "winLeadSecondPer")]
+        public float LeadAfterSecondWinPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "winOutshootOpp")]
+        public float OutshootWinPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "winOutshotByOpp")]
+        public float OutshotWinPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "faceOffsTaken")]
+        private float FaceoffsTakenValue { get; set; }
+
+        [JsonIgnore]
+        public int FaceoffsTaken
+        {
+            get
+            {
+                return Convert.ToInt32(this.FaceoffsTakenValue);
+            }
+        }
+
+        [JsonProperty(PropertyName = "faceOffsWon")]
+        private float FaceoffsWonValue { get; set; }
+
+        [JsonIgnore]
+        public int FaceoffsWon
+        {
+            get
+            {
+                return Convert.ToInt32(this.FaceoffsWonValue);
+            }
+        }
+
+        [JsonProperty(PropertyName = "faceOffsLost")]
+        private float FaceoffsLostValue { get; set; }
+
+        [JsonIgnore]
+        public int FaceoffsLost
+        {
+            get
+            {
+                return Convert.ToInt32(this.FaceoffsLostValue);
+            }
+        }
+
+        [JsonProperty(PropertyName = "faceOffWinPercentage")]
+        public float FaceoffWinPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "shootingPctg")]
+        public float ShootingPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "savePctg")]
+        public float SavePercentage { get; set; }
+    }
+    internal class NHLTeamNumericStatSplit
+    {
+        public TeamNumericStat Stat { get; set; }
+    }
+}

--- a/NHL.NET/Models/Team/NHLTeamRankStatSplit.cs
+++ b/NHL.NET/Models/Team/NHLTeamRankStatSplit.cs
@@ -1,0 +1,83 @@
+﻿using Newtonsoft.Json;
+
+namespace NHL.NET.Models.Team
+{
+    internal class TeamRankStat
+    {
+
+        public int GamesPlayed { get; set; }
+        public string Wins { get; set; }
+
+        public string Losses { get; set; }
+
+        [JsonProperty(PropertyName = "ot")]
+        public string OvertimeLosses { get; set; }
+
+        [JsonProperty(PropertyName = "pts")]
+        public string Points { get; set; }
+
+        [JsonProperty(PropertyName = "ptPctg")]
+        public string PointsPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "goalsPerGame")]
+        public string GoalsPerGame { get; set; }
+
+        public string GoalsAgainstPerGame { get; set; }
+
+        public string PowerPlayPercentage { get; set; }
+
+        public string PowerPlayGoals { get; set; }
+
+        public string PowerPlayGoalsAgainst { get; set; }
+
+        public string PowerPlayOpportunities { get; set; }
+
+        public string PenaltyKillOpportunities { get; set; }
+
+        public string PenaltyKillPercentage { get; set; }
+
+        public string ShotsPerGame { get; set; }
+
+        public string ShotsAllowed { get; set; }
+
+        [JsonProperty(PropertyName = "winScoreFirst")]
+        public string ScoreFirstWinPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "winOppScoreFirst")]
+        public string OppScoreFirstWinPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "winLeadFirstPer")]
+        public string LeadAfterFirstWinPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "winLeadSecondPer")]
+        public string LeadAfterSecondWinPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "winOutshootOpp")]
+        public string OutshootWinPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "winOutshotByOpp")]
+        public string OutshotWinPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "faceOffsTaken")]
+        public string FaceoffsTaken { get; set; }
+
+        [JsonProperty(PropertyName = "faceOffsWon")]
+        public string FaceoffsWon { get; set; }
+
+        [JsonProperty(PropertyName = "faceOffsLost")]
+        public string FaceoffsLost { get; set; }
+
+        [JsonProperty(PropertyName = "faceOffWinPercentage")]
+        public string FaceoffWinPercentage { get; set; }
+
+        [JsonProperty(PropertyName = "savePctRank")]
+        public string SavePercentage { get; set; }
+
+        [JsonProperty(PropertyName = "shootingPctRank")]
+        public string ShootingPercentage { get; set; }
+    }
+    internal class NHLTeamRankStatSplit
+    {
+        public TeamRankStat Stat { get; set; }
+    }
+}

--- a/NHL.NET/Models/Team/NHLTeamStats.cs
+++ b/NHL.NET/Models/Team/NHLTeamStats.cs
@@ -1,0 +1,111 @@
+﻿namespace NHL.NET.Models.Team
+{
+    public class NHLTeamStats
+    {
+        public int GamesPlayed { get; set; }
+
+        public int Wins { get; set; }
+
+        public string WinsRank { get; set; }
+
+        public int Losses { get; set; }
+
+        public string LossesRank { get; set; }
+
+        public int OvertimeLosses { get; set; }
+
+        public string OvertimeLossesRank { get; set; }
+
+        public int Points { get; set; }
+
+        public string PointsRank { get; set; }
+
+        public float PointsPercentage { get; set; }
+
+        public string PointsPercentageRank { get; set; }
+
+        public float GoalsPerGame { get; set; }
+
+        public string GoalsPerGameRank { get; set; }
+
+        public float GoalsAgainstPerGame { get; set; }
+
+        public string GoalsAgainstPerGameRank { get; set; }
+
+        public float PowerPlayPercentage { get; set; }
+
+        public string PowerPlayRank { get; set; }
+
+        public int PowerPlayGoals { get; set; }
+
+        public string PowerPlayGoalsRank { get; set; }
+
+        public int PowerPlayGoalsAgainst { get; set; }
+
+        public string PowerPlayGoalsAgainstRank { get; set; }
+
+        public int PowerPlayOpportunities { get; set; }
+
+        public string PowerPlayOpportunitiesRank { get; set; }
+
+        public float PenaltyKillPercentage { get; set; }
+
+        public string PenaltyKillRank { get; set; }
+
+        public float ShotsPerGame { get; set; }
+
+        public string ShotsPerGameRank { get; set; }
+
+        public float ShotsAllowed { get; set; }
+
+        public string ShotsAllowedRank { get; set; }
+
+        public float ScoreFirstWinPercentage { get; set; }
+
+        public string ScoreFirstWinPercentageRank { get; set; }
+
+        public float OppScoreFirstWinPercentage { get; set; }
+
+        public string OppScoreFirstWinPercentageRank { get; set; }
+
+        public float LeadAfterFirstWinPercentage { get; set; }
+
+        public string LeadAfterFirstWinPercentageRank { get; set; }
+
+        public float LeadAfterSecondWinPercentage { get; set; }
+
+        public string LeadAfterSecondWinPercentageRank { get; set; }
+
+        public float OutshootWinPercentage { get; set; }
+
+        public string OutshootWinPercentageRank { get; set; }
+
+        public float OutshotWinPercentage { get; set; }
+
+        public string OutshotWinPercentageRank { get; set; }
+
+        public int FaceoffsTaken { get; set; }
+
+        public string FaceoffsTakenRank { get; set; }
+
+        public int FaceoffsWon { get; set; }
+
+        public string FaceoffsWonRank { get; set; }
+
+        public int FaceoffsLost { get; set; }
+
+        public string FaceoffsLostRank { get; set; }
+
+        public float FaceoffWinPercentage { get; set; }
+
+        public string FaceoffWinPercentageRank { get; set; }
+
+        public float ShootingPercentage { get; set; }
+
+        public string ShootingPercentageRank { get; set; }
+
+        public float SavePercentage { get; set; }
+
+        public string SavePercentageRank { get; set; }
+    }
+}


### PR DESCRIPTION
Added 2 methods for teams endpoint and their associated tests:

- GetTeamStatsAsync / GetTeamStats

You can pass a specific season to get stats for the given season (ex. 20132014). If no string is passed (including empty/null) the stats returned are from the current season.

Closes #14 