### PR TITLE
Renamed team stats methods

### DIFF
--- a/NHL.NET.Test/TeamTests.cs
+++ b/NHL.NET.Test/TeamTests.cs
@@ -31,7 +31,7 @@ namespace NHL.NET.Test
         [Fact]
         public async Task Test_GetTeamStatsAsync_ReturnsTeamStats()
         {
-            var response = await _nhlClient.Teams.GetTeamStatsAsync(5);
+            var response = await _nhlClient.Teams.GetStatsAsync(5);
 
             Assert.NotNull(response);
         }
@@ -40,8 +40,8 @@ namespace NHL.NET.Test
         public async Task Test_GetTeamStatsAsync_SpecificSeason_ReturnsTeamStats()
         {
             // Compare 2 different seasons to verify different stats were returned.
-            var firstSeason = await _nhlClient.Teams.GetTeamStatsAsync(5, "20102011");
-            var secondSeason = await _nhlClient.Teams.GetTeamStatsAsync(5, "20092010");
+            var firstSeason = await _nhlClient.Teams.GetStatsAsync(5, "20102011");
+            var secondSeason = await _nhlClient.Teams.GetStatsAsync(5, "20092010");
 
             Assert.NotNull(firstSeason);
             Assert.NotNull(secondSeason);
@@ -53,7 +53,7 @@ namespace NHL.NET.Test
         [Fact]
         public async Task Test_GetTeamStatsAsync_EmptySeason_ReturnsTeamStats()
         {
-            var response = await _nhlClient.Teams.GetTeamStatsAsync(5, "");
+            var response = await _nhlClient.Teams.GetStatsAsync(5, "");
 
             Assert.NotNull(response);
         }
@@ -99,7 +99,7 @@ namespace NHL.NET.Test
         [Fact]
         public void Test_GetTeamStats_ReturnsTeamStats()
         {
-            var response = _nhlClient.Teams.GetTeamStats(5);
+            var response = _nhlClient.Teams.GetStats(5);
 
             Assert.NotNull(response);
         }
@@ -108,8 +108,8 @@ namespace NHL.NET.Test
         public void Test_GetTeamStats_SpecificSeason_ReturnsTeamStats()
         {
             // Compare 2 different seasons to verify different stats were returned.
-            var firstSeason = _nhlClient.Teams.GetTeamStats(5, "20102011");
-            var secondSeason = _nhlClient.Teams.GetTeamStats(5, "20092010");
+            var firstSeason = _nhlClient.Teams.GetStats(5, "20102011");
+            var secondSeason = _nhlClient.Teams.GetStats(5, "20092010");
 
             Assert.NotNull(firstSeason);
             Assert.NotNull(secondSeason);
@@ -121,7 +121,7 @@ namespace NHL.NET.Test
         [Fact]
         public void Test_GetTeamStats_EmptySeason_ReturnsTeamStats()
         {
-            var response = _nhlClient.Teams.GetTeamStats(5, "");
+            var response = _nhlClient.Teams.GetStats(5, "");
 
             Assert.NotNull(response);
         }

--- a/NHL.NET/Endpoints/Team/ITeamEndpoint.cs
+++ b/NHL.NET/Endpoints/Team/ITeamEndpoint.cs
@@ -6,11 +6,11 @@ namespace NHL.NET.Endpoints.Team
 {
     public interface ITeamEndpoint
     {
-        Task<NHLTeamStats> GetTeamStatsAsync(int teamId, string season = "");
+        Task<NHLTeamStats> GetStatsAsync(int teamId, string season = "");
         Task<NHLTeamList> GetAllAsync();
         Task<NHLTeam> GetByIdAsync(int teamId);
         Task<NHLTeamList> GetMultipleAsync(List<int> teamIds);
-        NHLTeamStats GetTeamStats(int teamId, string season = "");
+        NHLTeamStats GetStats(int teamId, string season = "");
         NHLTeamList GetAll();
         NHLTeam GetById(int teamId);
         NHLTeamList GetMultiple(List<int> teamIds);

--- a/NHL.NET/Endpoints/Team/TeamEndpoint.cs
+++ b/NHL.NET/Endpoints/Team/TeamEndpoint.cs
@@ -43,7 +43,7 @@ namespace NHL.NET.Endpoints.Team
             return teamList;
         }
 
-        public async Task<NHLTeamStats> GetTeamStatsAsync(int teamId, string season = "")
+        public async Task<NHLTeamStats> GetStatsAsync(int teamId, string season = "")
         {
             var queryString = "";
             if (!string.IsNullOrEmpty(season))
@@ -93,7 +93,7 @@ namespace NHL.NET.Endpoints.Team
             return teamList;
         }
 
-        public NHLTeamStats GetTeamStats(int teamId, string season = "")
+        public NHLTeamStats GetStats(int teamId, string season = "")
         {
             var queryString = "";
             if (!string.IsNullOrEmpty(season))


### PR DESCRIPTION
Simple rename. Having Team in the method names is redundant since the consumer already prefixes the call with `nhlClient.Teams`