### PR TITLE
Team rosters

### DIFF
--- a/NHL.NET.Test/TeamTests.cs
+++ b/NHL.NET.Test/TeamTests.cs
@@ -26,13 +26,13 @@ namespace NHL.NET.Test
             Assert.NotNull(response);
             Assert.Equal("Boston", response.LocationName);
             Assert.Equal("Bruins", response.TeamName);
+            Assert.NotNull(response.Roster);
         }
 
         [Fact]
         public async Task Test_GetTeamStatsAsync_ReturnsTeamStats()
         {
             var response = await _nhlClient.Teams.GetStatsAsync(5);
-
             Assert.NotNull(response);
         }
 
@@ -65,6 +65,8 @@ namespace NHL.NET.Test
 
             Assert.NotNull(response);
             Assert.True(response.Teams.Count == 3);
+            // Verifying roster is returned
+            Assert.NotNull(response.Teams[0].Roster);
         }
 
         [Fact]
@@ -85,6 +87,7 @@ namespace NHL.NET.Test
             Assert.NotNull(response);
             Assert.Equal("Boston", response.LocationName);
             Assert.Equal("Bruins", response.TeamName);
+            Assert.NotNull(response.Roster);
         }
 
         [Fact]
@@ -94,6 +97,7 @@ namespace NHL.NET.Test
 
             Assert.NotNull(response);
             Assert.True(response.Teams.Count == 3);
+            Assert.NotNull(response.Teams[0].Roster);
         }
 
         [Fact]

--- a/NHL.NET/Endpoints/Team/TeamEndpoints.cs
+++ b/NHL.NET/Endpoints/Team/TeamEndpoints.cs
@@ -20,13 +20,13 @@ namespace NHL.NET.Endpoints.Team
 
         public async Task<NHLTeamList> GetAllAsync()
         {
-            var teamList = await _requester.GetRequestAsync<NHLTeamList>(Urls.TeamUrl);
+            var teamList = await _requester.GetRequestAsync<NHLTeamList>($"{Urls.TeamUrl}?expand=team.roster");
             return teamList;
         }
 
         public async Task<NHLTeam> GetByIdAsync(int teamId)
         {
-            var teamList = await _requester.GetRequestAsync<NHLTeamList>($"{Urls.TeamUrl}/{teamId}");
+            var teamList = await _requester.GetRequestAsync<NHLTeamList>($"{Urls.TeamUrl}/{teamId}?expand=team.roster");
             if (teamList != null && teamList.Teams?.Count == 1)
             {
                 return teamList.Teams[0];
@@ -38,7 +38,7 @@ namespace NHL.NET.Endpoints.Team
         public async Task<NHLTeamList> GetMultipleAsync(List<int> teamIds)
         {
             var queryString = $"teamId={string.Join(",", teamIds)}";
-            var teamList = await _requester.GetRequestAsync<NHLTeamList>($"{Urls.TeamUrl}?{queryString}");
+            var teamList = await _requester.GetRequestAsync<NHLTeamList>($"{Urls.TeamUrl}?{queryString}&expand=team.roster");
 
             return teamList;
         }
@@ -76,7 +76,7 @@ namespace NHL.NET.Endpoints.Team
 
         public NHLTeam GetById(int teamId)
         {
-            var teamList = _requester.GetRequest<NHLTeamList>($"{Urls.TeamUrl}/{teamId}");
+            var teamList = _requester.GetRequest<NHLTeamList>($"{Urls.TeamUrl}/{teamId}?expand=team.roster");
             if (teamList != null && teamList.Teams?.Count == 1)
             {
                 return teamList.Teams[0];
@@ -88,7 +88,7 @@ namespace NHL.NET.Endpoints.Team
         public NHLTeamList GetMultiple(List<int> teamIds)
         {
             var queryString = $"teamId={string.Join(",", teamIds)}";
-            var teamList = _requester.GetRequest<NHLTeamList>($"{Urls.TeamUrl}?{queryString}");
+            var teamList = _requester.GetRequest<NHLTeamList>($"{Urls.TeamUrl}?{queryString}&expand=team.roster");
 
             return teamList;
         }

--- a/NHL.NET/Models/Player/NHLRosterPlayer.cs
+++ b/NHL.NET/Models/Player/NHLRosterPlayer.cs
@@ -1,0 +1,13 @@
+﻿using NHL.NET.Models.Position;
+
+namespace NHL.NET.Models.Player
+{
+    public class NHLRosterPlayer
+    {
+        public NHLSimplePlayer Player { get; set; }
+
+        public int JerseyNumber { get; set; }
+
+        public PlayerPosition Position { get; set; }
+    }
+}

--- a/NHL.NET/Models/Player/NHLSimplePlayer.cs
+++ b/NHL.NET/Models/Player/NHLSimplePlayer.cs
@@ -1,0 +1,9 @@
+﻿namespace NHL.NET.Models.Player
+{
+    public class NHLSimplePlayer
+    {
+        public int Id { get; set; }
+
+        public string FullName { get; set; }
+    }
+}

--- a/NHL.NET/Models/Team/NHLTeam.cs
+++ b/NHL.NET/Models/Team/NHLTeam.cs
@@ -21,6 +21,8 @@ namespace NHL.NET.Models.Team
 
         public NHLSimpleDivision Division { get; set; }
 
+        public NHLTeamRoster Roster { get; set; }
+
         public string Abbreviation { get; set; }
 
         public string TeamName { get; set; }

--- a/NHL.NET/Models/Team/NHLTeamRoster.cs
+++ b/NHL.NET/Models/Team/NHLTeamRoster.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+using NHL.NET.Models.Player;
+using System.Collections.Generic;
+
+namespace NHL.NET.Models.Team
+{
+    public class NHLTeamRoster
+    {
+        [JsonProperty(PropertyName = "roster")]
+        public List<NHLRosterPlayer> Players { get; set; }
+    }
+}


### PR DESCRIPTION
Added the `expand=team.roster` query param to some team endpoints to return rosters along with the team information.

Closes #26 